### PR TITLE
docs: add correct explanation to Fragments

### DIFF
--- a/documentation/DOC-HOME.md
+++ b/documentation/DOC-HOME.md
@@ -66,16 +66,48 @@ function MeuComponente() {
 }
 ```
 
+---
+
 ## Fragmentos
 
-Um [Componente](https://pt-br.reactjs.org/docs/glossary.html#components) é defindo por uma função que declarada retorna um [Elemento](#elementos) React .
+Os [Fragmentos](https://pt-br.reactjs.org/docs/fragments.html) permitem agrupar uma lista de filhos sem adicionar nós extras ao DOM.
 
 ```jsx
 function MeuComponente() {
-  return <div>Olá Mundo</div>;
+  return (
+    <React.Fragment>
+      <div>Olá</div>
+      <div>Mundo</div>
+    </React.Fragment>
+  );
 }
 ```
 
+Isto renderizará no DOM apenas os seguintes elementos:
+
+```html
+<body>
+  <div>Olá</div>
+  <div>Mundo</div>
+</body>
+```
+
+### Sintaxe Curta
+
+Existe uma sintaxe nova e mais curta que você pode utilizar para declarar fragmentos. Parecem tags vazias:
+
+```jsx
+function MeuComponente() {
+  return (
+    <>
+      <div>Olá</div>
+      <div>Mundo</div>
+    </>
+  );
+}
+```
+
+---
 
 ## Expressões
 


### PR DESCRIPTION
Add correct explanation to Fragments section, currenctly finds itself this way:

![image](https://user-images.githubusercontent.com/64603070/142745905-10577abf-dcc8-4401-8cf3-dcfffdb9f057.png)

With the correction:

![image](https://user-images.githubusercontent.com/64603070/142745951-fb0896ad-1fc6-460d-9c5c-c05159336b88.png)
